### PR TITLE
Fix Syncing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-somneo",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Somneo",
   "name": "homebridge-somneo",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A Homebridge plugin to control Philips Somneo clocks.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/somneoLightAccessory.ts
+++ b/src/somneoLightAccessory.ts
@@ -46,6 +46,11 @@ export class SomneoLightAccessory implements SomneoAccessory {
       const lightSettings = await this.somneoService.getLightSettings();
       this.isLightOn = lightSettings.onoff;
       this.lightBrightness = lightSettings.ltlvl * 4; // Philips stores up to 100 so multiply to get percentage
+
+      // Setters make HTTP calls
+      // To avoid that during polling refresh, call getters to refresh UI
+      this.lightService.getCharacteristic(this.platform.Characteristic.On);
+      this.lightService.getCharacteristic(this.platform.Characteristic.Brightness);
     } catch(err) {
       this.platform.log.error(`Error updating Lights: err=${err}`);
     }

--- a/src/somneoNightLightAccessory.ts
+++ b/src/somneoNightLightAccessory.ts
@@ -40,6 +40,10 @@ export class SomneoNightLightAccessory implements SomneoAccessory {
     try {
       const lightSettings = await this.somneoService.getLightSettings();
       this.isNightLightOn = lightSettings.ngtlt;
+
+      // Setters make HTTP calls
+      // To avoid that during polling refresh, call getters to refresh UI
+      this.nightLightService.getCharacteristic(this.platform.Characteristic.On);
     } catch(err) {
       this.platform.log.error(`Error updating Night Light: err=${err}`);
     }

--- a/src/somneoSensorAccessory.ts
+++ b/src/somneoSensorAccessory.ts
@@ -54,6 +54,12 @@ export class SomneoSensorAccessory implements SomneoAccessory {
       this.temperature = sensorReadings.mstmp;
       this.humidity = sensorReadings.msrhu;
       this.lightLevel = sensorReadings.mslux;
+
+      // Setters make HTTP calls
+      // To avoid that during polling refresh, call getters to refresh UI
+      this.temperatureService.getCharacteristic(this.platform.Characteristic.CurrentTemperature);
+      this.humidityService.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity);
+      this.lightService.getCharacteristic(this.platform.Characteristic.CurrentAmbientLightLevel);
     } catch (err) {
       this.platform.log.error(`Error updating Sensors: err=${err}`);
     }

--- a/src/somneoService.ts
+++ b/src/somneoService.ts
@@ -5,7 +5,6 @@ import { retryAsync } from 'ts-retry';
 import { SomneoConstants } from './somneoConstants';
 import { Light, LightSettings, NightLight, SensorReadings, SunsetProgram, UserSettings } from './types';
 
-
 export class SomneoService {
 
   private readonly http: AxiosInstance;
@@ -56,9 +55,9 @@ export class SomneoService {
 
     const body: SunsetProgram = { onoff: isOn };
 
-    this.http
+    await retryAsync(() => this.http
       .put(this.sunsetProgramUri, body)
-      .then(res => res.data);
+      .then(res => res.data));
   }
 
   async getLightSettings(): Promise<LightSettings> {
@@ -76,27 +75,27 @@ export class SomneoService {
 
     const body: NightLight = { ngtlt: isOn };
 
-    this.http
+    await retryAsync(() => this.http
       .put(this.lightsUri, body)
-      .then(res => res.data);
+      .then(res => res.data));
   }
 
   async modifyLightState(isOn: boolean): Promise<void> {
 
     const body: Light = isOn ? { onoff: true, tempy: false } : { onoff: false };
 
-    this.http
+    await retryAsync(() => this.http
       .put(this.lightsUri, body)
-      .then(res => res.data);
+      .then(res => res.data));
   }
 
   async modifyLightBrightness(brightness: number): Promise<void> {
 
-    // Scale to Somneo range 0..25
+    // Scale to Somneo range 0 to 25
     const body: Light = { ltlvl: Math.floor((brightness / 4) + 0.5) };
 
-    this.http
+    await retryAsync(() =>this.http
       .put(this.lightsUri, body)
-      .then(res => res.data);
+      .then(res => res.data));
   }
 }

--- a/src/somneoSunsetProgramSwitchAccessory.ts
+++ b/src/somneoSunsetProgramSwitchAccessory.ts
@@ -40,6 +40,10 @@ export class SomneoSunsetProgramSwitchAccessory implements SomneoAccessory {
     try {
       const sunsetProgram = await this.somneoService.getSunsetProgram();
       this.isProgramOn = sunsetProgram.onoff;
+
+      // Setters make HTTP calls
+      // To avoid that during polling refresh, call getters to refresh UI
+      this.switchService.getCharacteristic(this.platform.Characteristic.On);
     } catch(err) {
       this.platform.log.error(`Error updating Sunset Program Switch: err=${err}`);
     }


### PR DESCRIPTION
Why:
- Setting the private member alone will not cause a UI refresh.
- Ideally, we should call the property setter which will update the private member AND the UI, but the setter makes an HTTP call if the new value doesn't match the old.
- So when updateValues() is called, getters will be called after setting the private members. This should update the member and refresh the UI and reduce HTTP calls.