### PR TITLE
Define Minimum Lux Value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-somneo",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Somneo",
   "name": "homebridge-somneo",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A Homebridge plugin to control Philips Somneo clocks.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/somneoConstants.ts
+++ b/src/somneoConstants.ts
@@ -1,6 +1,7 @@
 export class SomneoConstants {
 
-  static DEFAULT_RETRY_OPTIONS = { delay: 100, maxTry: 5 };
+  static readonly SOMNEO = 'Somneo';
   static readonly SOMNEO_MANUFACTURER = 'Philips';
   static readonly SOMNEO_MODEL = 'Somneo HF3670/60';
+  static readonly HOMEBRIDGE_MIN_LUX_LEVEL = 0.0001;
 }

--- a/src/somneoLightAccessory.ts
+++ b/src/somneoLightAccessory.ts
@@ -6,6 +6,8 @@ import { SomneoAccessory } from './types';
 
 export class SomneoLightAccessory implements SomneoAccessory {
 
+  private static readonly NAME = 'Somneo Lights';
+
   private informationService: Service;
   private isLightOn = false;
   private lightBrightness = 0;
@@ -18,13 +20,13 @@ export class SomneoLightAccessory implements SomneoAccessory {
     private platform: SomneoPlatform,
   ) {
     this.somneoService = platform.SomneoService;
-    this.name = 'Somneo Lights';
+    this.name = SomneoLightAccessory.NAME;
 
     // set accessory information
     this.informationService = new this.platform.Service.AccessoryInformation()
       .setCharacteristic(this.platform.Characteristic.Manufacturer, SomneoConstants.SOMNEO_MANUFACTURER)
       .setCharacteristic(this.platform.Characteristic.Model, SomneoConstants.SOMNEO_MODEL)
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, String(this.platform.config.host));
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.platform.UserSettings.Host);
 
     this.lightService = new platform.Service.Lightbulb(this.name);
 
@@ -52,7 +54,7 @@ export class SomneoLightAccessory implements SomneoAccessory {
       this.lightBrightness = (lightSettings.ltlvl * 4);
       this.lightService.getCharacteristic(this.platform.Characteristic.Brightness).updateValue(this.lightBrightness);
     } catch(err) {
-      this.platform.log.error(`Error updating Lights: err=${err}`);
+      this.platform.log.error(`Error updating ${this.name}, err=${err}`);
     }
   }
 
@@ -69,7 +71,7 @@ export class SomneoLightAccessory implements SomneoAccessory {
 
     this.somneoService.modifyLightState(value as boolean);
 
-    this.platform.log.info('Set Light ->', value);
+    this.platform.log.info(`Set ${this.name} state ->`, value);
 
     this.isLightOn = value as boolean;
     callback(null);
@@ -77,7 +79,7 @@ export class SomneoLightAccessory implements SomneoAccessory {
 
   getLightOn(callback: CharacteristicGetCallback) {
 
-    this.platform.log.debug('Get Light ->', this.isLightOn);
+    this.platform.log.debug(`Get ${this.name} state ->`, this.isLightOn);
     callback(null, this.isLightOn);
   }
 
@@ -89,7 +91,7 @@ export class SomneoLightAccessory implements SomneoAccessory {
 
     this.somneoService.modifyLightBrightness(value as number);
 
-    this.platform.log.info('Set Light Brightness -> ', value);
+    this.platform.log.info(`Set ${this.name} brightness ->`, value);
 
     this.lightBrightness = value as number;
     callback(null);
@@ -97,7 +99,7 @@ export class SomneoLightAccessory implements SomneoAccessory {
 
   getLightBrightness(callback: CharacteristicGetCallback) {
 
-    this.platform.log.debug('Get Light Brightness -> ', this.lightBrightness);
+    this.platform.log.debug(`Get ${this.name} brightness ->`, this.lightBrightness);
     callback(null, this.lightBrightness);
   }
 

--- a/src/somneoNightLightAccessory.ts
+++ b/src/somneoNightLightAccessory.ts
@@ -6,6 +6,8 @@ import { SomneoAccessory } from './types';
 
 export class SomneoNightLightAccessory implements SomneoAccessory {
 
+  private static readonly NAME = `${SomneoConstants.SOMNEO} Night Light`;
+
   private informationService: Service;
   private isNightLightOn = false;
   private nightLightService : Service;
@@ -17,13 +19,13 @@ export class SomneoNightLightAccessory implements SomneoAccessory {
     private platform: SomneoPlatform,
   ) {
     this.somneoService = platform.SomneoService;
-    this.name = 'Somneo Night Light';
+    this.name = SomneoNightLightAccessory.NAME;
 
     // set accessory information
     this.informationService = new this.platform.Service.AccessoryInformation()
       .setCharacteristic(this.platform.Characteristic.Manufacturer, SomneoConstants.SOMNEO_MANUFACTURER)
       .setCharacteristic(this.platform.Characteristic.Model, SomneoConstants.SOMNEO_MODEL)
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, String(this.platform.config.host));
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.platform.UserSettings.Host);
 
     this.nightLightService = new platform.Service.Lightbulb(this.name);
 
@@ -43,7 +45,7 @@ export class SomneoNightLightAccessory implements SomneoAccessory {
       this.isNightLightOn = lightSettings.ngtlt;
       this.nightLightService.getCharacteristic(this.platform.Characteristic.On).updateValue(this.isNightLightOn);
     } catch(err) {
-      this.platform.log.error(`Error updating Night Light: err=${err}`);
+      this.platform.log.error(`Error updating ${this.name}, err=${err}`);
     }
   }
 
@@ -60,7 +62,7 @@ export class SomneoNightLightAccessory implements SomneoAccessory {
 
     this.somneoService.modifyNightLight(value as boolean);
 
-    this.platform.log.info('Set Night Light ->', value);
+    this.platform.log.info(`Set ${this.name} state ->`, value);
 
     this.isNightLightOn = value as boolean;
     callback(null);
@@ -68,7 +70,7 @@ export class SomneoNightLightAccessory implements SomneoAccessory {
 
   getNightLightOn(callback: CharacteristicGetCallback) {
 
-    this.platform.log.debug('Get Night Light ->', this.isNightLightOn);
+    this.platform.log.debug(`Get ${this.name} state ->`, this.isNightLightOn);
     callback(null, this.isNightLightOn);
   }
 

--- a/src/somneoService.ts
+++ b/src/somneoService.ts
@@ -2,10 +2,11 @@ import axios, { AxiosInstance } from 'axios';
 import { Logger } from 'homebridge';
 import https from 'https';
 import { retryAsync } from 'ts-retry';
-import { SomneoConstants } from './somneoConstants';
 import { Light, LightSettings, NightLight, SensorReadings, SunsetProgram, UserSettings } from './types';
 
 export class SomneoService {
+
+  private static readonly DEFAULT_RETRY_OPTIONS = { delay: 100, maxTry: 5 };
 
   private readonly http: AxiosInstance;
   private readonly host: string;
@@ -33,7 +34,7 @@ export class SomneoService {
 
     const sensorReadings: SensorReadings = await retryAsync(() => this.http
       .get(this.sensorsUri)
-      .then(res => res.data), SomneoConstants.DEFAULT_RETRY_OPTIONS);
+      .then(res => res.data), SomneoService.DEFAULT_RETRY_OPTIONS);
 
     this.log.debug(`Sensor Readings: temperature=${sensorReadings.mstmp} humidity=${sensorReadings.msrhu} light=${sensorReadings.mslux}`);
 
@@ -44,7 +45,7 @@ export class SomneoService {
 
     const sunsetProgram: SunsetProgram = await retryAsync(() => this.http
       .get(this.sunsetProgramUri)
-      .then(res => res.data), SomneoConstants.DEFAULT_RETRY_OPTIONS);
+      .then(res => res.data), SomneoService.DEFAULT_RETRY_OPTIONS);
 
     this.log.debug(`Sunset Program: on=${sunsetProgram.onoff}`);
 
@@ -64,7 +65,7 @@ export class SomneoService {
 
     const lightSettings: LightSettings = await retryAsync(() => this.http
       .get(this.lightsUri)
-      .then(res => res.data), SomneoConstants.DEFAULT_RETRY_OPTIONS);
+      .then(res => res.data), SomneoService.DEFAULT_RETRY_OPTIONS);
 
     this.log.debug(`Light Settings: lightLevel=${lightSettings.ltlvl} lightOn=${lightSettings.onoff} nightLightOn=${lightSettings.ngtlt}`);
 

--- a/src/somneoSunsetProgramSwitchAccessory.ts
+++ b/src/somneoSunsetProgramSwitchAccessory.ts
@@ -6,6 +6,8 @@ import { SomneoAccessory } from './types';
 
 export class SomneoSunsetProgramSwitchAccessory implements SomneoAccessory {
 
+  private static readonly NAME = `${SomneoConstants.SOMNEO} Sunset Program`;
+
   private informationService: Service;
   private isProgramOn = false;
   private somneoService: SomneoService;
@@ -17,13 +19,13 @@ export class SomneoSunsetProgramSwitchAccessory implements SomneoAccessory {
     private platform: SomneoPlatform,
   ) {
     this.somneoService = this.platform.SomneoService;
-    this.name = 'Somneo Sunset Program';
+    this.name = SomneoSunsetProgramSwitchAccessory.NAME;
 
     // set accessory information
     this.informationService = new this.platform.Service.AccessoryInformation()
       .setCharacteristic(this.platform.Characteristic.Manufacturer, SomneoConstants.SOMNEO_MANUFACTURER)
       .setCharacteristic(this.platform.Characteristic.Model, SomneoConstants.SOMNEO_MODEL)
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, String(this.platform.config.host));
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.platform.UserSettings.Host);
 
     this.switchService = new platform.Service.Switch(this.name);
 
@@ -43,7 +45,7 @@ export class SomneoSunsetProgramSwitchAccessory implements SomneoAccessory {
       this.isProgramOn = sunsetProgram.onoff;
       this.switchService.getCharacteristic(this.platform.Characteristic.On).updateValue(this.isProgramOn);
     } catch(err) {
-      this.platform.log.error(`Error updating Sunset Program Switch: err=${err}`);
+      this.platform.log.error(`Error updating ${this.name}, err=${err}`);
     }
   }
 
@@ -60,7 +62,7 @@ export class SomneoSunsetProgramSwitchAccessory implements SomneoAccessory {
 
     this.somneoService.modifySunsetProgram(value as boolean);
 
-    this.platform.log.info('Set Sunset Program ->', value);
+    this.platform.log.info(`Set ${this.name} ->`, value);
 
     this.isProgramOn = value as boolean;
     callback(null);
@@ -68,7 +70,7 @@ export class SomneoSunsetProgramSwitchAccessory implements SomneoAccessory {
 
   getProgramOn(callback: CharacteristicGetCallback) {
 
-    this.platform.log.debug('Get Sunset Program ->', this.isProgramOn);
+    this.platform.log.debug(`Get ${this.name} ->`, this.isProgramOn);
     callback(null, this.isProgramOn);
   }
 


### PR DESCRIPTION
- Homebridge does not let a lux sensor be 0. The minimum value is 0.0001
- If a value is less than that, the somneoSensorAccessory will set the
  lux value to the minimum.
- Additionally cleaned up constants and names.