### PR TITLE
Fix Switching Bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-somneo",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Somneo",
   "name": "homebridge-somneo",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A Homebridge plugin to control Philips Somneo clocks.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -51,11 +51,11 @@ export class SomneoPlatform implements StaticPlatformPlugin {
 
     this.log.debug(`Will poll every ${this.UserSettings.PollingMilliSeconds}ms`);
 
-    this.SomneoAccessories.forEach(somneoAccessory => {
-      setInterval(() => {
+    setInterval(() => {
+      this.SomneoAccessories.forEach(somneoAccessory => {
         this.log.debug(`Updating accessory=${somneoAccessory.name} values.`);
         somneoAccessory.updateValues();
-      }, this.UserSettings.PollingMilliSeconds);
-    });
+      });
+    }, this.UserSettings.PollingMilliSeconds);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,11 @@ export interface SomneoAccessory extends AccessoryPlugin {
   updateValues(): Promise<void>;
 }
 
+export interface SomneoBinaryAccessory extends SomneoAccessory {
+  getAffectedAccessories(): SomneoBinaryAccessory[];
+  turnOff(): void;
+}
+
 export interface SensorReadings {
   mslux: number;
   mstmp: number;


### PR DESCRIPTION
Why:
- Some functions are blocking and don't allow the user to concurrently
  do other things.
- Any program that involves the lights works this way. For instance, if
  the nightlight is on, the main light cannot be. If the sunset program
  is running, music that is playing will need to be turned off.
- Switches were not being updated properly to reflect this. In fact,
  a waterfall effect was happening where turning on the main light would
  turn off the night light, which would turn off the main light again.

How:
- Update the turnOff method to explicitly set the private member, call
  the SomneoService and update the value of the switch. This avoids the
  waterfall.

Note:
- The server in the clock is slow. And the server only accepts one
  connection at a time (it seems), which means that if polling and
  control happen simultaneously, one of them will fail. I may need to
  figure out how to pause the polling when control happens.

  At this time is best to keep commands to the clock slow in Home UI or
  automations.