### PR TITLE
Fix Somneo Audio Turn On

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-somneo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Somneo",
   "name": "homebridge-somneo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A Homebridge plugin to control Philips Somneo clocks.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/lib/somneoAudioAccessory.ts
+++ b/src/lib/somneoAudioAccessory.ts
@@ -126,9 +126,14 @@ export class SomneoAudioAccessory extends PlatformAccessory {
       this.turnOffConflictingAccessories();
     }
 
-    this.platform.SomneoService.modifyPlaySettingsState(boolValue, this.source, this.volume).then(() => {
+    this.platform.SomneoService.modifyPlaySettingsState(boolValue).then(() => {
       this.isActive = boolValue;
       this.platform.log.info(`Set ${this.displayName} state ->`, this.isActive);
+
+      // TODO use UserSettings values
+      this.channel = String(SomneoConstants.DEFAULT_ACTIVE_INPUT);
+      this.source = SomneoConstants.SOURCE_FM_RADIO;
+      this.updateActiveInput();
     }).catch(err => this.platform.log.error(`Error setting ${this.displayName} state to ${boolValue}, err=${err}`));
   }
 
@@ -223,6 +228,7 @@ export class SomneoAudioAccessory extends PlatformAccessory {
   private updateChannelAndSource() {
 
     if (this.activeInput === undefined) {
+      // TODO Read defaults from UserSettings
       this.channel = String(SomneoConstants.DEFAULT_ACTIVE_INPUT);
       this.source = SomneoConstants.SOURCE_FM_RADIO;
       return;

--- a/src/lib/somneoService.ts
+++ b/src/lib/somneoService.ts
@@ -133,10 +133,11 @@ export class SomneoService {
     return playSettings;
   }
 
-  async modifyPlaySettingsState(isOn: boolean, source?: string, volume?: number ) {
+  async modifyPlaySettingsState(isOn: boolean ) {
 
+    // TODO read favorite input from UserSettings
     const body: PlaySettings = isOn ?
-      { onoff: true, tempy: false, snddv: source || SomneoConstants.SOURCE_FM_RADIO, sdvol: volume || SomneoConstants.VOLUME_MIN }
+      { onoff: true, snddv: SomneoConstants.SOURCE_FM_RADIO, sndch: String(SomneoConstants.DEFAULT_ACTIVE_INPUT) }
       : { onoff: false };
 
     await retryAsync(() => this.http


### PR DESCRIPTION
- Send the correct PUT command to turn on the audio.
- Now when it turns on it defaults to FM Preset 1 and so does the UI.
- A future release will allow users to select their "favorite" input.