### PR TITLE
Fix Audio Switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Below, is a chart explaining what will be turned off (if on) when an accessory i
 | RelaxBreathe<br />Turns On | **Turns Off** | **Turns Off** | **Turns Off** | N/A | **Turns Off**|
 | Audio<br/>Turns On | Unaffected | Unaffected | **Turns Off** | **Turns Off** | N/A
 
-
 ## Installation
 
 Before installing this plugin, you should install Homebridge using the [official instructions](https://github.com/homebridge/homebridge/wiki).
@@ -54,7 +53,6 @@ Before installing this plugin, you should install Homebridge using the [official
 | **name** | *Yes* | Set the plugin name for display in the Homebridge logs | `Homebridge Somneo` |
 | **host** | *Yes* | IP address or hostname of the Somneo clock. | N/A |
 
-
 ### Optional Parameters
 
 | Field | Required | Description                              | Default Value |
@@ -68,9 +66,19 @@ Before installing this plugin, you should install Homebridge using the [official
 | **enableRelaxBreatheProgram** | No | Boolean value for whether or not to include the RelaxBreathe Program switch. | `true` |
 | **enableSunsetProgram** | No | Boolean value for whether or not to include the Sunset Program switch. | `true` |
 | **enableAudio** | No | Boolean value for whether or not to include the Audio receiver to use the FM Radio and/or Auxiliary Input. | `true` |
+| **favoriteInput** | No | Numeric value specifying the input for the Somneo Audio to go to the first time its turned on in a session. After changing the input, the Somneo will go to the last used input. | `1` or FM Preset 1 |
 
-##### Configuration Parameters Note
+##### Configuration Parameters Notes
+
 Due to the way that the Config UI X visual editor works, in order to not force users to write to their config file when they want to use accessory but have not selected anything, the boolean values can either be a literal boolean of `true` or a string boolean of `"true"`.
+
+###### Input Enumeration
+1. FM Preset 1 is `1`
+2. FM Preset 2 is `2`
+3. FM Preset 3 is `3`
+4. FM Preset 4 is `4`
+5. FM Preset 5 is `5`
+6. Auxiliary is `6`
 
 ##### Somneo Audio Accessory Note
 
@@ -102,7 +110,6 @@ However, due the way that audio receivers are implemented in Homebridge, they mu
 
 ## Future Plans
 - Currently the plugin only supports one Somneo clock. Not sure how many people have multiple clocks.
-- Ability to specify a "favorite" audio input that the audio accessory will jump to when turned on.
 - No support for sound sensor. HomeKit does not have a sound level sensor. I thought about having an occupancy sensor, but would need to know what sound level occupied/not should be considered.
 - Better error handling. I am a Java developer by trade and am still learning Typescript :).
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -167,6 +167,49 @@
             ]
           }
         ]
+      },
+      "favoriteInput": {
+        "title": "Favorite Input",
+        "type": "number",
+        "oneOf": [
+          {
+            "title": "FM Preset 1",
+            "enum": [
+              1
+            ]
+          },
+          {
+            "title": "FM Preset 2",
+            "enum": [
+              2
+            ]
+          },
+          {
+            "title": "FM Preset 3",
+            "enum": [
+              3
+            ]
+          },
+          {
+            "title": "FM Preset 4",
+            "enum": [
+              4
+            ]
+          },
+          {
+            "title": "FM Preset 5",
+            "enum": [
+              5
+            ]
+          },
+          {
+            "title": "Auxiliary",
+            "enum": [
+              6
+            ]
+          }
+        ],
+        "description": "This is the input that will be used when the audio device is turned on."
       }
     }
   },
@@ -243,6 +286,9 @@
               "items": [
                 {
                   "key": "enableAudio"
+                },
+                {
+                  "key": "favoriteInput"
                 }
               ]
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-somneo",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Somneo",
   "name": "homebridge-somneo",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A Homebridge plugin to control Philips Somneo clocks.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/lib/somneoAudioInput.ts
+++ b/src/lib/somneoAudioInput.ts
@@ -1,8 +1,0 @@
-export enum SomneoAudioInput {
-  FM_1 = 1,
-  FM_2,
-  FM_3,
-  FM_4,
-  FM_5,
-  AUX
-}

--- a/src/lib/somneoConstants.ts
+++ b/src/lib/somneoConstants.ts
@@ -8,13 +8,14 @@ export class SomneoConstants {
   static readonly DEFAULT_HUMIDITY = 0;
   static readonly DEFAULT_LUX_LEVEL = 0.0001;
   static readonly DEFAULT_TEMPERATURE = 0;
-  static readonly VOLUME_MAX = 25;
-  static readonly VOLUME_MIN = 1;
+  static readonly INPUT_AUX_NUM = 6;
+  static readonly NUM_FM_RADIO_CHANNELS = 5;
+  static readonly MANUFACTURER = 'Philips';
+  static readonly MODEL = 'Somneo HF3670/60';
+  static readonly SOMNEO = 'Somneo';
   static readonly SOURCE_AUX = 'aux';
   static readonly SOURCE_FM_RADIO = 'fmr';
   static readonly SOURCE_OFF = 'off';
-  static readonly MANUFACTURER = 'Philips';
-  static readonly MODEL = 'Somneo HF3670/60';
-  static readonly NUM_FM_RADIO_CHANNELS = 5;
-  static readonly SOMNEO = 'Somneo';
+  static readonly VOLUME_MAX = 25;
+  static readonly VOLUME_MIN = 1;
 }

--- a/src/lib/userSettings.ts
+++ b/src/lib/userSettings.ts
@@ -1,51 +1,82 @@
-import { PlatformConfig } from 'homebridge';
+import { SomneoPlatform } from '../somneoPlatform';
 import { RequestedAccessory } from './requestedAccessory';
+import { SomneoConstants } from './somneoConstants';
 export class UserSettings {
 
   private static DEFAULT_POLLING_SECONDS = 30;
   private static DEFAULT_BOOLEAN_JSON_VALUE = true;
 
   public readonly Host: string;
+  public FavoriteChannel= String(SomneoConstants.DEFAULT_ACTIVE_INPUT);
+  public FavoriteSource = SomneoConstants.SOURCE_FM_RADIO;
   public readonly PollingMilliSeconds: number;
   public readonly RequestedAccessories: RequestedAccessory[] = [];
 
   constructor(
-    private config: PlatformConfig,
+    private platform: SomneoPlatform,
   ) {
-    this.Host = this.config.host;
+    this.Host = this.platform.config.host;
 
     // If the user has not specified a polling interval, default to 30s (in milliseconds)
-    this.PollingMilliSeconds = (this.config.pollingSeconds || UserSettings.DEFAULT_POLLING_SECONDS) * 1000;
+    this.PollingMilliSeconds = (this.platform.config.pollingSeconds || UserSettings.DEFAULT_POLLING_SECONDS) * 1000;
 
-    if (this.getBooleanValue(this.config.enableHumiditySensor)) {
+    this.buildRequestedAccessories();
+    this.buildChannelAndSource();
+  }
+
+  private buildChannelAndSource() {
+
+    // If Audio disabled, just leave values as defaults to save time
+    if (!this.RequestedAccessories.includes(RequestedAccessory.AUDIO)) {
+      return;
+    }
+
+    // Likewise, if the user did not specify, leave it as the default
+    if (this.platform.config.favoriteInput === undefined) {
+      return;
+    }
+
+    if (Number(this.platform.config.favoriteInput) === SomneoConstants.INPUT_AUX_NUM) {
+      this.FavoriteSource = SomneoConstants.SOURCE_AUX;
+      this.FavoriteChannel = String(SomneoConstants.DEFAULT_ACTIVE_INPUT);
+      return;
+    }
+
+    this.FavoriteSource = SomneoConstants.SOURCE_FM_RADIO;
+    this.FavoriteChannel = String(this.platform.config.favoriteInput);
+  }
+
+  private buildRequestedAccessories() {
+
+    if (this.getBooleanValue(this.platform.config.enableHumiditySensor)) {
       this.RequestedAccessories.push(RequestedAccessory.SENSOR_HUMIDITY);
     }
 
-    if (this.getBooleanValue(this.config.enableLuxSensor)) {
+    if (this.getBooleanValue(this.platform.config.enableLuxSensor)) {
       this.RequestedAccessories.push(RequestedAccessory.SENSOR_LUX);
     }
 
-    if (this.getBooleanValue(this.config.enableTemperatureSensor)) {
+    if (this.getBooleanValue(this.platform.config.enableTemperatureSensor)) {
       this.RequestedAccessories.push(RequestedAccessory.SENSOR_TEMPERATURE);
     }
 
-    if(this.getBooleanValue(this.config.enableMainLight)) {
+    if(this.getBooleanValue(this.platform.config.enableMainLight)) {
       this.RequestedAccessories.push(RequestedAccessory.LIGHT_MAIN);
     }
 
-    if (this.getBooleanValue(this.config.enableNightLight)) {
+    if (this.getBooleanValue(this.platform.config.enableNightLight)) {
       this.RequestedAccessories.push(RequestedAccessory.LIGHT_NIGHT_LIGHT);
     }
 
-    if (this.getBooleanValue(this.config.enableRelaxBreatheProgram)) {
+    if (this.getBooleanValue(this.platform.config.enableRelaxBreatheProgram)) {
       this.RequestedAccessories.push(RequestedAccessory.SWITCH_RELAXBREATHE);
     }
 
-    if (this.getBooleanValue(this.config.enableSunsetProgram)) {
+    if (this.getBooleanValue(this.platform.config.enableSunsetProgram)) {
       this.RequestedAccessories.push(RequestedAccessory.SWITCH_SUNSET);
     }
 
-    if (this.getBooleanValue(this.config.enableAudio)) {
+    if (this.getBooleanValue(this.platform.config.enableAudio)) {
       this.RequestedAccessories.push(RequestedAccessory.AUDIO);
     }
   }

--- a/src/somneoPlatform.ts
+++ b/src/somneoPlatform.ts
@@ -36,8 +36,8 @@ export class SomneoPlatform implements StaticPlatformPlugin {
     public readonly config: PlatformConfig,
     public readonly api: API,
   ) {
-    this.UserSettings = new UserSettings(this.config);
-    this.SomneoService = new SomneoService(this.log, this.UserSettings);
+    this.UserSettings = new UserSettings(this);
+    this.SomneoService = new SomneoService(this);
 
     this.buildAccessories();
 


### PR DESCRIPTION
- When you turn on the radio for the first time it will default to your
  favorite input. This is useful for using AUX if you don't care about
  FM radio.
- After that, the input will be saved on and reused next time it's
  turned on.