### PR TITLE
Add Lux Sensor If No Sensor Config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-somneo",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Somneo",
   "name": "homebridge-somneo",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A Homebridge plugin to control Philips Somneo clocks.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/lib/somneoClock.ts
+++ b/src/lib/somneoClock.ts
@@ -10,8 +10,8 @@ export class SomneoClock {
     RequestedAccessory.LIGHT_NIGHT_LIGHT];
 
   private static readonly SENSOR_ACCESSORIES = [RequestedAccessory.SENSOR_HUMIDITY,
-    RequestedAccessory.SENSOR_TEMPERATURE,
-    RequestedAccessory.SENSOR_HUMIDITY];
+    RequestedAccessory.SENSOR_LUX,
+    RequestedAccessory.SENSOR_TEMPERATURE];
 
   private static readonly SWITCH_ACCESSORIES = [RequestedAccessory.SWITCH_RELAXBREATHE,
     RequestedAccessory.SWITCH_SUNSET];


### PR DESCRIPTION
Why:
- If the sensor config was empty, only humidity and temperature would be
  added.

How:
- Fix the static array that represents all sensors to include lux.